### PR TITLE
Remove outdated 5-rotation note

### DIFF
--- a/index.html
+++ b/index.html
@@ -100,7 +100,6 @@
           <div class="card-body">
             <div class="d-flex justify-content-between align-items-center mb-2">
               <div class="section-title">要素コンポーザ</div>
-              <div class="small text-secondary">5回転はA無効・可用回転のみ表示</div>
             </div>
 
             <!-- タブ: ジャンプ/スピン/シークエンス -->


### PR DESCRIPTION
## Summary
- delete "5回転はA無効" message from jump composer section

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68babf212bf0832fa4631c0a3e485592