### PR TITLE
GOEボタンをスマホ画面に合わせて折り返し表示

### DIFF
--- a/index.html
+++ b/index.html
@@ -194,7 +194,7 @@
                   </div>
                   <div class="col-12">
                     <div class="text-secondary small mb-1">GOE</div>
-                    <div class="btn-group btn-group-sm" role="group" aria-label="GOE選択">
+                    <div class="btn-group btn-group-sm goe-buttons" role="group" aria-label="GOE選択">
                       <input type="radio" class="btn-check" name="goe" value="-5" id="goe-5">
                       <label class="btn btn-outline-danger" for="goe-5">-5</label>
                       
@@ -268,7 +268,7 @@
                 
                 <div class="mt-3">
                   <div class="text-secondary small mb-1">GOE</div>
-                  <div class="btn-group btn-group-sm" role="group" aria-label="GOE選択">
+                  <div class="btn-group btn-group-sm goe-buttons" role="group" aria-label="GOE選択">
                     <input type="radio" class="btn-check" name="goe-spin" value="-5" id="goe-spin-5">
                     <label class="btn btn-outline-danger" for="goe-spin-5">-5</label>
                     
@@ -335,7 +335,7 @@
                 
                 <div class="mt-3">
                   <div class="text-secondary small mb-1">GOE</div>
-                  <div class="btn-group btn-group-sm" role="group" aria-label="GOE選択">
+                  <div class="btn-group btn-group-sm goe-buttons" role="group" aria-label="GOE選択">
                     <input type="radio" class="btn-check" name="goe-seq" value="-5" id="goe-seq-5">
                     <label class="btn btn-outline-danger" for="goe-seq-5">-5</label>
                     

--- a/style.css
+++ b/style.css
@@ -155,3 +155,14 @@ img, table {
   box-shadow: 0 2px 8px rgba(33,37,41,.08);
   padding: 8px 12px;
 }
+
+/* GOEボタンを複数行に折り返し、均等に配置 */
+.goe-buttons {
+  display: flex;
+  flex-wrap: wrap;
+  width: 100%;
+}
+
+.goe-buttons .btn {
+  flex: 1 1 14%;
+}


### PR DESCRIPTION
## 概要
- GOEボタンをFlexbox化し、スマホ画面で折り返せるように調整
- ボタン幅を均等にするスタイルを追加

## テスト
- `npm test`（package.jsonがなく失敗）

------
https://chatgpt.com/codex/tasks/task_e_68bc157c9f74832fa414f93302d52229